### PR TITLE
Updates `holidays` gem to support newer ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.6.2'
+ruby '> 2.3'
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    business-days (3.1.5)
+    business-days (4.0.0)
       activesupport (~> 6.0)
       holidays (~> 8.5)
       tzinfo (~> 2.0)
@@ -54,4 +54,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   1.17.2
+   2.2.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,25 +3,25 @@ PATH
   specs:
     business-days (3.1.5)
       activesupport (~> 6.0)
-      holidays (~> 7.1)
+      holidays (~> 8.5)
       tzinfo (~> 2.0)
       tzinfo-data (~> 1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.3.1)
+    activesupport (6.1.5.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.10)
     diff-lcs (1.4.4)
-    holidays (7.1.0)
-    i18n (1.8.10)
+    holidays (8.5.0)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.14.4)
+    minitest (5.15.0)
     rake (13.0.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -38,9 +38,9 @@ GEM
     rspec-support (3.10.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2021.1)
+    tzinfo-data (1.2022.1)
       tzinfo (>= 1.0.0)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby
@@ -51,7 +51,7 @@ DEPENDENCIES
   rspec
 
 RUBY VERSION
-   ruby 2.6.2p47
+   ruby 2.7.2p137
 
 BUNDLED WITH
    1.17.2

--- a/business-days.gemspec
+++ b/business-days.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'business-days'
-  s.version     = '3.1.5'
+  s.version     = '4.0.0'
   s.date        = '2021-02-04'
   s.summary     = "Business Days"
   s.description = "Methods to check if a given date is a business days and to perform computations based on Business days."

--- a/business-days.gemspec
+++ b/business-days.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", '~> 6.0'
   s.add_dependency "tzinfo", '~> 2.0'
   s.add_dependency "tzinfo-data", '~> 1'
-  s.add_dependency "holidays", '~> 7.1'
+  s.add_dependency "holidays", '~> 8.5'
   s.metadata = {
     "changelog_uri"     => "https://github.com/cloudwalkio/business-days/blob/master/CHANGELOG.md",
     "documentation_uri" => "http://www.rubydoc.info/github/cloudwalkio/business-days",


### PR DESCRIPTION
The gem `holidays` broke ruby support on the 7.1.0 -> 8.0.0 bump
- 7.1.0: does not support ruby 3.x
- 8.0.0: does not support ruby <= 2.3

(reference: https://github.com/holidays/holidays/releases/tag/v7.1.0)
