### PR TITLE
Updated gem activesupport

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     business-days (4.0.0)
-      activesupport (~> 6.0)
+      activesupport (~> 7.0)
       holidays (~> 8.5)
       tzinfo (~> 2.0)
       tzinfo-data (~> 1)
@@ -10,40 +10,38 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.5.1)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     concurrent-ruby (1.1.10)
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     holidays (8.5.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     minitest (5.15.0)
-    rake (13.0.3)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    rake (13.0.6)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.1)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.1)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2022.1)
       tzinfo (>= 1.0.0)
-    zeitwerk (2.5.4)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   business-days!
@@ -51,7 +49,7 @@ DEPENDENCIES
   rspec
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 2.7.5p203
 
 BUNDLED WITH
-   2.2.9
+   2.3.6

--- a/business-days.gemspec
+++ b/business-days.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.files       = ["lib/business-days.rb"]
   s.homepage    = 'http://rubygems.org/gems/business-days'
   s.license     = 'MIT'
-  s.add_dependency "activesupport", '~> 6.0'
+  s.add_dependency "activesupport", '~> 7.0'
   s.add_dependency "tzinfo", '~> 2.0'
   s.add_dependency "tzinfo-data", '~> 1'
   s.add_dependency "holidays", '~> 8.5'


### PR DESCRIPTION
This makes the business-days gem compatible with Rails 7.