### PR TITLE
Remove last year day

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    business-days (4.1.0)
-      activesupport (>= 6.0, < 7.1)
+    business-days (4.2.0)
+      activesupport
       holidays (~> 8.5)
       tzinfo (~> 2.0)
       tzinfo-data (~> 1)
@@ -52,4 +52,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.9
+   2.4.4

--- a/business-days.gemspec
+++ b/business-days.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'business-days'
-  s.version     = '4.1.1'
+  s.version     = '4.2.0'
   s.date        = '2021-02-04'
   s.summary     = "Business Days"
   s.description = "Methods to check if a given date is a business days and to perform computations based on Business days."

--- a/lib/business-days.rb
+++ b/lib/business-days.rb
@@ -24,9 +24,9 @@ class BusinessDaysSingleton
     end
 
     # 3. Add the latest business day in each year (it's a bank holiday)
-    (from..to).each do |year|
-      @holidays.push(latest_non_bank_business_day(year))
-    end
+    # (from..to).each do |year|
+    #   @holidays.push(latest_non_bank_business_day(year))
+    # end
   end
 
   # Compute the date obtained by adding the given amount of business days to the given time.

--- a/spec/business_days_from_utc_time_spec.rb
+++ b/spec/business_days_from_utc_time_spec.rb
@@ -68,7 +68,7 @@ describe 'test' do
     # This date, in Brasilia time, will be 2021-12-30 (-03:00)
     time = Time.parse('2021-12-30T15:00:00Z')
 
-    expect(BusinessDays.business_days_from_utc_time(1, time)).to eql(Time.parse('2022-01-03T03:00:00Z'))
+    expect(BusinessDays.business_days_from_utc_time(1, time)).to eql(Time.parse('2021-12-31T03:00:00Z'))
   end
 
   it '2020-12-30 plus 1 business days should be 2020-12-31 if ignoring latest day of the year' do


### PR DESCRIPTION
### Description
Now the date 12-31 is consider a transactional date, but the gem not consider this way and this is causing a inconsistency in of transactions expected to this date every moth
![image](https://github.com/cloudwalk/business-days/assets/117363748/722a6868-931f-448e-a706-806e64613599)
